### PR TITLE
Npp83

### DIFF
--- a/NppAStyle/NppAStyle.rc
+++ b/NppAStyle/NppAStyle.rc
@@ -1,5 +1,6 @@
 // Microsoft Visual C++ generated resource script.
 //
+#include <windows.h>
 #include "resource.h"
 #include "NppAStyleVersion.h"
 
@@ -8,7 +9,7 @@
 //
 // Generated from the TEXTINCLUDE 2 resource.
 //
-#include "afxres.h"
+// #include "afxres.h"
 
 /////////////////////////////////////////////////////////////////////////////
 #undef APSTUDIO_READONLY_SYMBOLS
@@ -20,6 +21,8 @@
 #ifdef _WIN32
 LANGUAGE LANG_NEUTRAL, SUBLANG_NEUTRAL
 #endif //_WIN32
+
+#define IDC_STATIC -1
 
 #ifdef APSTUDIO_INVOKED
 /////////////////////////////////////////////////////////////////////////////

--- a/NppAStyle/NppAStyleOptionDlg.cpp
+++ b/NppAStyle/NppAStyleOptionDlg.cpp
@@ -139,7 +139,7 @@ void NppAStyleOptionDlg::updateDlgTabsetting()
 	if( m_astyleOption->isSameAsNppCurView )
 	{
 		HWND hWndNppCurrentScintilla = getNppCurrentScintilla();
-		m_astyleOption->iTabSize = ::SendMessage( hWndNppCurrentScintilla, SCI_GETTABWIDTH, 0, 0 );
+		m_astyleOption->iTabSize = ( int )::SendMessage( hWndNppCurrentScintilla, SCI_GETTABWIDTH, 0, 0 );
 		m_astyleOption->isUseSpace = 0 == ::SendMessage( hWndNppCurrentScintilla, SCI_GETUSETABS, 0, 0 );
 	}
 	SendDlgItemMessage( IDC_TXT_PREVIEW, SCI_SETTABWIDTH, (WPARAM) m_astyleOption->iTabSize, 0 );
@@ -168,7 +168,7 @@ void NppAStyleOptionDlg::updateDlgPreviewText()
 	}
 	else
 	{
-		unsigned int pos = ::SendMessage( hWndPreviewCtrl, SCI_GETCURRENTPOS, 0, 0 );
+		Sci_Position pos = ::SendMessage( hWndPreviewCtrl, SCI_GETCURRENTPOS, 0, 0 );
 		::SendMessage( hWndPreviewCtrl, SCI_SETWRAPMODE, SC_WRAP_NONE, 0 );
 		LPARAM lw = ::SendMessage( hWndPreviewCtrl, SCI_TEXTWIDTH, STYLE_LINENUMBER, (LPARAM) "_999" );
 		::SendMessage( hWndPreviewCtrl, SCI_SETMARGINWIDTHN, 0, lw );
@@ -806,7 +806,7 @@ INT_PTR CALLBACK NppAStyleOptionDlg::DlgOptionProc( UINT Message, WPARAM wParam,
 
 				if( HIWORD( wParam ) == CBN_SELCHANGE )
 				{
-					int ItemIndex = ::SendMessage( ( HWND ) lParam, ( UINT ) CB_GETCURSEL, 0, 0 );
+					int ItemIndex = ( int )::SendMessage( ( HWND ) lParam, ( UINT ) CB_GETCURSEL, 0, 0 );
 					switch( LOWORD( wParam ) )
 					{
 						case IDC_CBB_TABSIZE:

--- a/NppAStyle/PluginDefinition.cpp
+++ b/NppAStyle/PluginDefinition.cpp
@@ -209,7 +209,7 @@ void AStyleCode( const char *textBuffer, const NppAStyleOption &m_astyleOption, 
 		HWND curScintilla = getNppCurrentScintilla();
 
 		isUseSpace = 0 == ::SendMessage( curScintilla, SCI_GETUSETABS, 0, 0 );
-		iTabSize = ::SendMessage( curScintilla, SCI_GETTABWIDTH, 0, 0 );
+		iTabSize = ( int )::SendMessage( curScintilla, SCI_GETTABWIDTH, 0, 0 );
 
 		if( isUseSpace == false )
 		{
@@ -284,13 +284,13 @@ void formatCode()
 		return;
 	}
 
-	int textSize = ( int )::SendMessage( curScintilla, SCI_GETLENGTH, 0, 0 );
+	Sci_Position textSize = ( Sci_Position )::SendMessage( curScintilla, SCI_GETLENGTH, 0, 0 );
 	textSize += 1;
 	char *textBuffer = ( char * )::malloc( textSize );
 	::SendMessage( curScintilla, SCI_GETTEXT, ( WPARAM )textSize, ( LPARAM )textBuffer );
 
-	const unsigned int pos_cur = ::SendMessage( curScintilla, SCI_GETCURRENTPOS, 0, 0 );
-	const unsigned int lineNumber_cur = ::SendMessage( curScintilla, SCI_LINEFROMPOSITION, pos_cur, 0 );
+	const Sci_Position pos_cur = ::SendMessage( curScintilla, SCI_GETCURRENTPOS, 0, 0 );
+	const Sci_Position lineNumber_cur = ::SendMessage( curScintilla, SCI_LINEFROMPOSITION, pos_cur, 0 );
 
 	AStyleCode( textBuffer, astyleOption, formatRunProcCallback, curScintilla );
 


### PR DESCRIPTION
Small changes to switch int=>Sci_Position (to accommodate 64-bit and new N++ 8.3 changes) as well as cast some Scintilla API returns to avoid compile warnings.